### PR TITLE
Docker setup

### DIFF
--- a/validation-api/Dockerfile
+++ b/validation-api/Dockerfile
@@ -10,4 +10,5 @@ COPY . .
 
 EXPOSE 5000
 ENV PYTHONPATH="${PYTHONPATH}:/app"
-CMD ["flask", "--app", "api/app.py", "run", "--host=0.0.0.0"]
+CMD ["flask", "--app", "/app/api/app.py", "run", "--host=0.0.0.0"]
+

--- a/validation-api/Dockerfile
+++ b/validation-api/Dockerfile
@@ -11,4 +11,3 @@ COPY . .
 EXPOSE 5000
 ENV PYTHONPATH="${PYTHONPATH}:/app"
 CMD ["flask", "--app", "/app/api/app.py", "run", "--host=0.0.0.0"]
-

--- a/validation-api/Dockerfile
+++ b/validation-api/Dockerfile
@@ -9,4 +9,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 EXPOSE 5000
+ENV PYTHONPATH="${PYTHONPATH}:/app"
 CMD ["flask", "--app", "api/app.py", "run", "--host=0.0.0.0"]

--- a/validation-api/Dockerfile
+++ b/validation-api/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 5000
+CMD ["flask", "--app", "api/app.py", "run", "--host=0.0.0.0"]

--- a/validation-api/api/app.py
+++ b/validation-api/api/app.py
@@ -1,7 +1,7 @@
 import json
 from http import HTTPStatus
 
-from api.utils import load_schema
+from utils import load_schema
 from flask import Flask, Response, request
 from jsonschema import validate
 from jsonschema.exceptions import SchemaError, ValidationError
@@ -48,4 +48,4 @@ def validate_config():
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(host="0.0.0.0")

--- a/validation-api/api/app.py
+++ b/validation-api/api/app.py
@@ -1,7 +1,7 @@
 import json
 from http import HTTPStatus
 
-from utils import load_schema
+from api.utils import load_schema
 from flask import Flask, Response, request
 from jsonschema import validate
 from jsonschema.exceptions import SchemaError, ValidationError

--- a/validation-api/docker-compose.yaml
+++ b/validation-api/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  web:
+    build: .
+    ports:
+      - "5000:5000"

--- a/validation-api/pyproject.toml
+++ b/validation-api/pyproject.toml
@@ -12,3 +12,6 @@ python = "^3.10"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+pythonpath = "validation-api"


### PR DESCRIPTION
Addresses #3 --

1. Creates `Dockerfile` to package api code into an image.
2. Creates a `docker-compose.yaml` to automatically build and run the container.
3. Updates repository structure to clean up Python imports and avoid PYTHONPATH errors in the container. 

To test locally:
```
docker compose up
curl localhost:5000
```

I will create a separate issue to update the default server to use something more production-ready, like uWSGI or nginx before deploying to Azure.