### PR TITLE
Azure bash

### DIFF
--- a/validation-api/Makefile
+++ b/validation-api/Makefile
@@ -1,4 +1,4 @@
-COMMANDS = build run push-to-registry deploy login
+COMMANDS = build run push-to-registry login
 
 .PHONY: $(COMMANDS)
 

--- a/validation-api/Makefile
+++ b/validation-api/Makefile
@@ -1,0 +1,19 @@
+COMMANDS = build run push-to-registry deploy login
+
+.PHONY: $(COMMANDS)
+
+AZURE_CR_NAME := cfaprdbatchcr
+IMAGE_NAME = '$(AZURE_CR_NAME).azurecr.io/config-validation-service:latest'
+
+build:
+	docker-compose build --no-cache
+
+run:
+	docker-compose up
+
+login: 
+	az login
+
+push-to-registry: build
+	az acr login --name $(AZURE_CR_NAME)
+	docker push $(IMAGE_NAME)

--- a/validation-api/Makefile
+++ b/validation-api/Makefile
@@ -11,7 +11,7 @@ build:
 run:
 	docker-compose up
 
-login: 
+login:
 	az login
 
 push-to-registry: build

--- a/validation-api/docker-compose.yaml
+++ b/validation-api/docker-compose.yaml
@@ -3,3 +3,4 @@ services:
     build: .
     ports:
       - "5000:5000"
+    image: cfaprdbatchcr.azurecr.io/config-validation-service:latest


### PR DESCRIPTION
Closes #10 

Basic Makefile for interacting with Azure Container Registry and building the Docker image. I wanted to add a `deploy` target to deploy the latest image to Azure Container Instances, but I need to get permissions to do that from EDAV, so will handle separately.