### PR TITLE
Pull schema from Azure Blob Storage

### DIFF
--- a/validation-api/api/app.py
+++ b/validation-api/api/app.py
@@ -32,10 +32,15 @@ def validate_config():
         flask.Response: response object with valid JSON or error message.
     """
 
-    # Load schema; locally for now. Return early if loading fails
+    # Load schema either locally or from Azure, depending on url param.
+    use_local = request.args.get("local", default=False, type=bool)
     try:
-        schema = load_schema(local=True)
-    except (json.decoder.JSONDecodeError, FileNotFoundError) as err:
+        schema = load_schema(local=use_local)
+    except (
+        json.decoder.JSONDecodeError,
+        FileNotFoundError,
+        ValueError,
+    ) as err:
         return Response(response=str(err), status=HTTPStatus.BAD_REQUEST)
 
     # Validate configuration in request body against schema

--- a/validation-api/api/app.py
+++ b/validation-api/api/app.py
@@ -1,8 +1,8 @@
 import json
 from http import HTTPStatus
 
-from api.utils import CONSTANTS, load_schema
-from azure_utils.auth import obtain_credential, read_config
+from api.utils import load_schema
+from azure_utils.auth import obtain_sp_credential
 from flask import Flask, Response, request
 from jsonschema import validate
 from jsonschema.exceptions import SchemaError, ValidationError
@@ -54,11 +54,8 @@ def auth():
     Returns:
         flask.Response: response object with success string or error message.
     """
-    config_path = CONSTANTS.get("auth_config_path", "")
-    config = read_config(config_path)
-
     try:
-        obtain_credential(config, credential_type="default")
+        obtain_sp_credential()
     except (ValueError, LookupError) as err:
         return Response(response=str(err), status=HTTPStatus.UNAUTHORIZED)
 

--- a/validation-api/api/utils.py
+++ b/validation-api/api/utils.py
@@ -1,9 +1,15 @@
 import json
 import os
 
+from azure_utils.auth import obtain_sp_credential
+from azure_utils.storage import obtain_schema_from_blob_storage
+
 CONSTANTS = {
     "base_dir": os.path.abspath(os.path.dirname(__file__)),
     "local_schema_path": "local_schema.json",
+    "azure_storage_account_url": "https://cfaazurebatchprd.blob.core.windows.net/",
+    "azure_container_name": "cfa-config-validation",
+    "azure_schema_filename": "schema.json",
 }
 
 
@@ -27,9 +33,22 @@ def load_schema(local=True):
     Raises:
         json.decoder.JSONDecodeError: If the schema JSON is invalid.
     """
-    schema_path = os.path.join(
-        CONSTANTS.get("base_dir", ""), CONSTANTS.get("local_schema_path", "")
+
+    if local:
+        # Use local schema instead of pulling from Azure
+        schema_path = os.path.join(
+            CONSTANTS.get("base_dir", ""),
+            CONSTANTS.get("local_schema_path", ""),
+        )
+        with open(schema_path) as fp:
+            schema = json.load(fp)
+        return schema
+
+    sp_credential = obtain_sp_credential()
+    schema = obtain_schema_from_blob_storage(
+        sp_credential=sp_credential,
+        account_url=CONSTANTS["azure_storage_account_url"],
+        container_name=CONSTANTS["azure_container_name"],
+        blob_name=CONSTANTS["azure_schema_filename"],
     )
-    with open(schema_path) as fp:
-        schema = json.load(fp)
     return schema

--- a/validation-api/api/utils.py
+++ b/validation-api/api/utils.py
@@ -4,7 +4,6 @@ import os
 CONSTANTS = {
     "base_dir": os.path.abspath(os.path.dirname(__file__)),
     "local_schema_path": "local_schema.json",
-    "auth_config_path": "azure_utils/config.toml",
 }
 
 

--- a/validation-api/api/utils.py
+++ b/validation-api/api/utils.py
@@ -47,8 +47,8 @@ def load_schema(local=True):
     sp_credential = obtain_sp_credential()
     schema = obtain_schema_from_blob_storage(
         sp_credential=sp_credential,
-        account_url=CONSTANTS["azure_storage_account_url"],
-        container_name=CONSTANTS["azure_container_name"],
-        blob_name=CONSTANTS["azure_schema_filename"],
+        account_url=CONSTANTS.get("azure_storage_account_url", ""),
+        container_name=CONSTANTS.get("azure_container_name", ""),
+        blob_name=CONSTANTS.get("azure_schema_filename", ""),
     )
     return schema

--- a/validation-api/azure_utils/auth.py
+++ b/validation-api/azure_utils/auth.py
@@ -1,7 +1,6 @@
 import os
-
 import toml
-from azure.identity import ClientSecretCredential
+from azure.identity import DefaultAzureCredential
 
 
 def read_config(config_path):
@@ -15,29 +14,24 @@ def read_config(config_path):
     return config
 
 
-def obtain_credential(config, credential_type="default"):
-    """Obtains client credentials from Azure KeyVault.
-    Args:
-        config (dict): Dictionary of configuration values.
+def obtain_sp_credential():
+    """Obtains service principal credentials from Azure.
     Returns:
-        Instance of ClientSecretCredential.
+        Instance of DefaultAzureCredential.
     """
 
     # Since this will be run from a Docker container,
-    # we only use the SP Credential to Authenticate.
+    # we only use the SP Credential to authenticate.
 
-    # Pull values from injected environment variables
-    tenant_id = os.environ.get("TENANT_ID", "")
-    application_id = os.environ.get("APPLICATION_ID", "")
-    client_secret = os.environ.get("SP_SECRET", "")
+    # Check that env variables are set
+    tenant_id = os.environ.get("AZURE_TENANT_ID", "")
+    application_id = os.environ.get("AZURE_CLIENT_ID", "")
+    client_secret = os.environ.get("AZURE_CLIENT_SECRET", "")
     if "" in [tenant_id, client_secret, application_id]:
         error_message = "Azure secrets not found in environment. Ensure secrets are configured properly."
         raise ValueError(error_message)
 
-    sp_credential = ClientSecretCredential(
-        tenant_id=tenant_id,
-        client_id=application_id,
-        client_secret=client_secret,
-    )
+    # The DefaultAzureCredential reads from the environment directly
+    sp_credential = DefaultAzureCredential()
 
-    return sp_credential, client_secret
+    return sp_credential

--- a/validation-api/azure_utils/auth.py
+++ b/validation-api/azure_utils/auth.py
@@ -1,4 +1,5 @@
 import os
+
 import toml
 from azure.identity import DefaultAzureCredential
 

--- a/validation-api/azure_utils/storage.py
+++ b/validation-api/azure_utils/storage.py
@@ -1,4 +1,5 @@
 import json
+
 from azure.storage.blob import BlobServiceClient
 
 

--- a/validation-api/azure_utils/storage.py
+++ b/validation-api/azure_utils/storage.py
@@ -1,0 +1,38 @@
+import json
+from azure.storage.blob import BlobServiceClient
+
+
+def obtain_schema_from_blob_storage(
+    sp_credential=None, account_url="", container_name="", blob_name=""
+):
+    """Function to pull the modeling
+    pipeline schema from blob storage.
+    Args:
+        sp_credential (DefaultAzureCredential): Service principal credential object
+        for use in authenticating with Storage API.
+    Returns:
+        dict: Schema dictionary.
+    Raises:
+        json.decoder.JSONDecodeError: If the schema JSON is invalid.
+        ValueError: If sp_credential is invalid or BlobServiceClient
+        fails to instantiate.
+    """
+
+    if not sp_credential:
+        raise ValueError("Service principal credential not provided.")
+
+    # Instantiate BlobStorageClient
+    blob_service_client = BlobServiceClient(
+        account_url, credential=sp_credential
+    )
+
+    # Retrieve blob from client
+    blob_client = blob_service_client.get_blob_client(
+        container=container_name, blob=blob_name
+    )
+
+    # encoding param is necessary for readall() to return str, otherwise it returns bytes
+    downloader = blob_client.download_blob(max_concurrency=1, encoding="UTF-8")
+    blob_text = downloader.readall()
+    schema = json.loads(blob_text)
+    return schema

--- a/validation-api/docker-compose.yaml
+++ b/validation-api/docker-compose.yaml
@@ -5,6 +5,6 @@ services:
       - "5000:5000"
     image: cfaprdbatchcr.azurecr.io/config-validation-service:latest
     environment:
-      TENANT_ID: ${TENANT_ID}
-      APPLICATION_ID: ${APPLICATION_ID}
-      SP_SECRET: ${SP_SECRET}
+      AZURE_TENANT_ID: ${AZURE_TENANT_ID}
+      AZURE_CLIENT_ID: ${AZURE_CLIENT_ID}
+      AZURE_CLIENT_SECRET: ${AZURE_CLIENT_SECRET}

--- a/validation-api/poetry.lock
+++ b/validation-api/poetry.lock
@@ -122,6 +122,26 @@ isodate = ">=0.6.1"
 typing-extensions = ">=4.0.1"
 
 [[package]]
+name = "azure-storage-blob"
+version = "12.23.0"
+description = "Microsoft Azure Blob Storage Client Library for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "azure_storage_blob-12.23.0-py3-none-any.whl", hash = "sha256:8ac4b34624ed075eda1e38f0c6dadb601e1b199e27a09aa63edc429bf4a23329"},
+    {file = "azure_storage_blob-12.23.0.tar.gz", hash = "sha256:2fadbceda1d99c4a72dfd32e0122d7bca8b5e8d2563f5c624d634aeaff49c9df"},
+]
+
+[package.dependencies]
+azure-core = ">=1.30.0"
+cryptography = ">=2.1.4"
+isodate = ">=0.6.1"
+typing-extensions = ">=4.6.0"
+
+[package.extras]
+aio = ["azure-core[aio] (>=1.30.0)"]
+
+[[package]]
 name = "blinker"
 version = "1.8.2"
 description = "Fast, simple object-to-object and broadcast signaling"
@@ -1181,4 +1201,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "05cf2f762675e8c73dee13ebcac09f1033177ef85a86f3d1bf534b72e8baa5dd"
+content-hash = "f7938aa6694e4556329cbe4f1d379b1d88449865f207ea3d02c5a045cf493ce7"

--- a/validation-api/pyproject.toml
+++ b/validation-api/pyproject.toml
@@ -39,6 +39,7 @@ pytest = "^8.3.3"
 azure-identity = "^1.17.1"
 azure-keyvault = "^4.2.0"
 toml = "^0.10.2"
+azure-storage-blob = "^12.23.0"
 
 
 [build-system]

--- a/validation-api/tests/test_server.py
+++ b/validation-api/tests/test_server.py
@@ -20,7 +20,7 @@ def test_valid_configuration():
     with open(config_path) as fp:
         config = json.load(fp)
 
-    response = client.post("/validate", json=config)
+    response = client.post("/validate?local=True", json=config)
     assert response.status == "200 OK"
     assert json.loads(response.data) == config
 
@@ -31,7 +31,7 @@ def test_invalid_configuration():
     with open(config_path) as fp:
         config = json.load(fp)
 
-    response = client.post("/validate", json=config)
+    response = client.post("/validate?local=True", json=config)
     assert response.status == "400 BAD REQUEST"
     assert (
         "Additional properties are not allowed ('reference_date', 'report_date' were unexpected)"


### PR DESCRIPTION
Closes #14 --

Configuration updates to pull schema from Azure Blob Storage, currently in a new `cfa-config-validation` container under the cfaazurebatchprd storage account.

1. Cleaned up credentials management. I figured out that if AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_CLIENT_SECRET are set as environment variables, then we can just use the DefaultAzureCredential and it'll read from the environment directly. Pretty nice.
2. Updated tests to use local schema
3. Added utility functions to interact with blob storage and serialize schema blob into json
4. Updated validate route to load schema either from Azure or locally, based on query param