### PR TITLE
Removing explicit check for environment variables

### DIFF
--- a/azure_utils/auth.py
+++ b/azure_utils/auth.py
@@ -1,5 +1,3 @@
-import os
-
 import toml
 from azure.identity import DefaultAzureCredential
 
@@ -19,20 +17,12 @@ def obtain_sp_credential():
     """Obtains service principal credentials from Azure.
     Returns:
         Instance of DefaultAzureCredential.
+    Raises:
+        LookupError if credential not found.
     """
 
-    # Since this will be run from a Docker container,
-    # we only use the SP Credential to authenticate.
-
-    # Check that env variables are set
-    tenant_id = os.environ.get("AZURE_TENANT_ID", "")
-    application_id = os.environ.get("AZURE_CLIENT_ID", "")
-    client_secret = os.environ.get("AZURE_CLIENT_SECRET", "")
-    if "" in [tenant_id, client_secret, application_id]:
-        error_message = "Azure secrets not found in environment. Ensure secrets are configured properly."
-        raise ValueError(error_message)
-
     # The DefaultAzureCredential reads from the environment directly
+    # if running locally. The deployed version uses Managed Identity
     sp_credential = DefaultAzureCredential()
 
     return sp_credential


### PR DESCRIPTION
We have configured Azure Managed Identity https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview on the container instance running the service. For local development, secrets are injected at build time in the docker-compose. When deployed, we don't need to include these secrets and DefaultAzureCredential will pull from the managed identity runtime. This PR just removes the explicit check for environment variables so that it doesn't error out when deployed.