### PR TITLE
Production server + Dockerfile cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,9 @@
 FROM python:3.11-slim
 
-# Configure Poetry
-ENV POETRY_VERSION=1.8.3
-ENV POETRY_HOME=/opt/poetry
-ENV POETRY_VENV=/opt/poetry-venv
-ENV POETRY_CACHE_DIR=/opt/.cache
+# Install poetry
 
-# Install poetry separated from system interpreter
-RUN python3 -m venv $POETRY_VENV \
-    && $POETRY_VENV/bin/pip install -U pip setuptools \
-    && $POETRY_VENV/bin/pip install poetry==${POETRY_VERSION}
-
-# Add `poetry` to PATH
-ENV PATH="${PATH}:${POETRY_VENV}/bin"
+RUN pip3 install poetry
+RUN poetry config virtualenvs.create false
 
 WORKDIR /cfa-config-validation
 
@@ -22,6 +13,7 @@ RUN poetry install
 
 COPY . .
 
+# Run production server
 EXPOSE 5000
 ENV PYTHONPATH="${PYTHONPATH}:/cfa-config-validation"
-CMD ["poetry", "run", "python", "-m", "flask", "--app", "/cfa-config-validation/app/app.py", "run", "--host=0.0.0.0"]
+CMD ["gunicorn", "--config", "gunicorn_config.py", "app.app:app"]

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,0 +1,12 @@
+import os
+
+
+workers = int(os.environ.get("GUNICORN_PROCESSES", "2"))
+
+threads = int(os.environ.get("GUNICORN_THREADS", "4"))
+
+bind = os.environ.get("GUNICORN_BIND", "0.0.0.0:5000")
+
+forwarded_allow_ips = "*"
+
+secure_scheme_headers = {"X-Forwarded-Proto": "https"}

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,6 +1,5 @@
 import os
 
-
 workers = int(os.environ.get("GUNICORN_PROCESSES", "2"))
 
 threads = int(os.environ.get("GUNICORN_THREADS", "4"))

--- a/poetry.lock
+++ b/poetry.lock
@@ -509,6 +509,27 @@ async = ["asgiref (>=3.2)"]
 dotenv = ["python-dotenv"]
 
 [[package]]
+name = "gunicorn"
+version = "23.0.0"
+description = "WSGI HTTP Server for UNIX"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "gunicorn-23.0.0-py3-none-any.whl", hash = "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d"},
+    {file = "gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec"},
+]
+
+[package.dependencies]
+packaging = "*"
+
+[package.extras]
+eventlet = ["eventlet (>=0.24.1,!=0.36.0)"]
+gevent = ["gevent (>=1.4.0)"]
+setproctitle = ["setproctitle"]
+testing = ["coverage", "eventlet", "gevent", "pytest", "pytest-cov"]
+tornado = ["tornado (>=0.2)"]
+
+[[package]]
 name = "identify"
 version = "2.6.0"
 description = "File identification library for Python"
@@ -1201,4 +1222,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "f7938aa6694e4556329cbe4f1d379b1d88449865f207ea3d02c5a045cf493ce7"
+content-hash = "8178649fafdc6064dc8bd7a7bf7b5a33f411e4512c3fe97dc9d0cafa57a39770"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ azure-identity = "^1.17.1"
 azure-keyvault = "^4.2.0"
 toml = "^0.10.2"
 azure-storage-blob = "^12.23.0"
+gunicorn = "^23.0.0"
 
 
 [build-system]


### PR DESCRIPTION
Closes #9 --

Swap out the built-in Flask development server with [Gunicorn](https://gunicorn.org/), which is better suited for production environments because it can handle concurrency, multiple requests, etc. 

Also removed setting up a virtual environment in the Docker container, as it is already isolated from the host machine, so this is just unnecessary overhead. 