### PR TITLE
Updating GHA to use self-hosted runners

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: cfa-cdcgov
     environment: production
     steps:
     - name: Azure Service Principal CLI login

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   install-and-test:
-    runs-on: ubuntu-latest
+    runs-on: cfa-cdcgov
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Closes #24 --

Using the newly-configured self-hosted runners to handle the test and deploy stages.